### PR TITLE
add config.rules, now we can set rules without json/yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,14 @@ express-acl depends on the role of each authenticated user to pick the correspon
 # API
 There are two API methods for express-acl.
 
-**config[type: function, params: filename<string>,path<string>, yml<boolean>, encoding, baseUrl]**
+**config[type: function, params: filename<string>,path<string>, yml<boolean>, encoding, baseUrl, rules]**
 
 This methods loads the configuration json file. When this method it looks for `nacl.json` the root folder if path is not specified.
 **filename**: Name of the ACL rule file e.g nacl.json
 **path**: Location of the ACL rule file
 **yml**: when set to true means use yaml parser else JSON parser
 **baseUrl**: The base url of your API e.g /developer/v1
+**rules**: The rules you can direct set for nacl
 
 ```js
   var acl = require('express-acl');
@@ -180,6 +181,12 @@ This methods loads the configuration json file. When this method it looks for `n
 
   // When specifying path you can also rename the json file e.g
   // The above file can be acl.json or nacl.json or any_file_name.json
+
+  acl.config({
+	rules: rulesArray
+  });
+
+  // When you use rules api, nacl will **not** to find the json/yaml file, so you can save your acl-rules with any Database; 
 
   ```
 

--- a/lib/nacl.js
+++ b/lib/nacl.js
@@ -34,26 +34,34 @@
       encoding = options.encoding;
       opt.baseUrl = options.baseUrl;
     }
+    
+    if (options && options.rules) {
 
-    var filename = yml ? 'nacl.yml' : 'nacl.json';
+      rules = options.rules;
 
+    } else {
 
-    filename = options && options.filename ? options.filename : filename;
-
-    /**
-     * Get the path
-     */
-
-    path = options && options.path ? options.path : path;
-
-    /**
-     * Merge filename and path
-     */
-
-    path = filename && path ? (path + '/' + filename) : filename;
+      var filename = yml ? 'nacl.yml' : 'nacl.json';
 
 
-    rules = helper.getRules(path, encoding, yml);
+      filename = options && options.filename ? options.filename : filename;
+
+      /**
+       * Get the path
+       */
+
+      path = options && options.path ? options.path : path;
+
+      /**
+       * Merge filename and path
+       */
+
+      path = filename && path ? (path + '/' + filename) : filename;
+
+
+      rules = helper.getRules(path, encoding, yml);
+
+    }
 
     if (!_.isArray(rules)) {
       log.warn('WARNING', rules);

--- a/tests/behavior/nacl.config.rules.spec.js
+++ b/tests/behavior/nacl.config.rules.spec.js
@@ -1,0 +1,46 @@
+(function() {
+  'use strict';
+
+  var assert = require('assert');
+  var acl = require('../../');
+
+  //
+  var rulesArr = [{
+    group: 'user',
+    permissions: [{
+      resource: 'users',
+      methods: [
+	'GET',
+	'POST',
+	'DELETE'
+      ],
+      action: 'allow'
+    }]
+  }];
+
+  describe('Array testing', function() {
+    var rules;
+    beforeEach(function(done) {
+      rules = acl.config({
+	rules: rulesArr
+      });
+      done();
+    });
+
+    it('should can direct setted config rules by Array', function() {
+      var expectedRule = [{
+        group: 'user',
+        permissions: [{
+          resource: 'users',
+          methods: ['GET', 'POST', 'DELETE'],
+          action: 'allow'
+        }]
+      }];
+      assert(rules, true);
+      assert(typeof rules, 'object');
+      assert(rules.length, 1);
+      assert.deepEqual(rules, expectedRule);
+
+    });
+  });
+})();


### PR DESCRIPTION
I work for on a mysql-base  system, and we need save our acl-roles in db to let other system can access/edit it, so i think if i can set rules to config will resolve our problem.
like your express-acl module;